### PR TITLE
Refactor Navigation: permissions & mobile UX

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
-import { Heart, Users, Calendar, Clock, FileText, Settings, Menu, LogOut, Bell, Activity } from "lucide-react";
+import { Heart, Users, Clock, FileText, Menu, LogOut, Bell, Activity } from "lucide-react";
 import { useState, useMemo, useEffect } from "react";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useLocation, useNavigate, NavLink } from "react-router-dom";
-import { ROUTE_PERMISSIONS, isVolunteer, isCoordinator } from "@/config/permissions";
+import { ROUTE_PERMISSIONS, isVolunteer } from "@/config/permissions";
 import { canAccessRoute } from "@/lib/permissions";
 
 export const Navigation = () => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import { Heart, Users, Calendar, Clock, FileText, Settings, Menu, LogOut, Bell, 
 import { useState, useMemo, useEffect } from "react";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useLocation, useNavigate, NavLink } from "react-router-dom";
-import { ROUTE_PERMISSIONS } from "@/config/permissions";
+import { ROUTE_PERMISSIONS, isVolunteer, isCoordinator } from "@/config/permissions";
 import { canAccessRoute } from "@/lib/permissions";
 
 export const Navigation = () => {
@@ -84,21 +84,24 @@ export const Navigation = () => {
 
           {/* Desktop Navigation */}
           <div className="hidden md:block">
-            <div className="ml-10 flex items-baseline space-x-4">
+            <div className="ml-10 flex items-baseline space-x-4 md:space-x-2 lg:space-x-4">
               {allowedNavItems.map((item) => {
                 const Icon = item.icon;
                 return (
                   <NavLink
                     key={item.name}
                     to={item.href}
-                    className={({ isActive }) => `px-3 py-2 rounded-md text-sm font-medium flex items-center space-x-2 transition-smooth ${
+                    className={({ isActive }) => `px-2 md:px-3 py-2 rounded-md text-sm font-medium flex items-center md:space-x-2 transition-smooth ${
                       isActive
                         ? "bg-gradient-primary text-primary-foreground shadow-soft"
                         : "text-muted-foreground hover:text-foreground hover:bg-accent"
                     }`}
+                    aria-label={item.name}
+                    title={item.name}
                   >
                     <Icon className="h-4 w-4" />
-                    <span>{item.name}</span>
+                    {/* label: hidden at md (compact), visible according to role: VOLUNTEER=lg, COORDINATOR=xl, default=lg */}
+                    <span className={`hidden ${isVolunteer(user?.role) ? 'lg:inline' : 'xl:inline'}`}>{item.name}</span>
                   </NavLink>
                 );
               })}
@@ -114,7 +117,8 @@ export const Navigation = () => {
               onClick={handleProfileClick}
             >
               <Users className="h-4 w-4 mr-2" />
-              Profile
+              {/* VOLUNTEER: visible at lg, COORDINATOR: visible at xl, others: visible at lg */}
+              <span className={`hidden ${isVolunteer(user?.role) ? 'lg:inline' :  'xl:inline'}`}>Profile</span>
             </Button>
             <Button 
               variant="ghost" 
@@ -123,7 +127,7 @@ export const Navigation = () => {
               className="text-red-600 hover:text-red-700"
             >
               <LogOut className="h-4 w-4 mr-2" />
-              Logout
+              <span className="hidden lg:inline">Logout</span>
             </Button>
           </div>
 
@@ -202,6 +206,8 @@ export const Navigation = () => {
                   className={({ isActive }) => `w-full flex items-center px-3 py-3 rounded-md text-base font-medium justify-start space-x-3 transition-smooth ${
                     isActive ? "bg-gradient-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent"
                   }`}
+                  aria-label="Profile"
+                  title="Profile"
                 >
                   <Users className="h-5 w-5 mr-2" />
                   <span>Profile</span>
@@ -212,6 +218,8 @@ export const Navigation = () => {
                     setIsOpen(false);
                     openLogoutConfirm();
                   }}
+                  aria-label="Logout"
+                  title="Logout"
                 >
                   <LogOut className="h-5 w-5 mr-2" />
                   <span>Logout</span>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,9 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { Heart, Users, Calendar, Clock, FileText, Settings, Menu, LogOut, Bell, Activity } from "lucide-react";
-import { useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useState, useMemo, useEffect } from "react";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
+import { useLocation, useNavigate, NavLink } from "react-router-dom";
 import { ROUTE_PERMISSIONS } from "@/config/permissions";
+import { canAccessRoute } from "@/lib/permissions";
 
 export const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -13,7 +15,7 @@ export const Navigation = () => {
   const location = useLocation(); // 👈 para saber la ruta actual
   
 
-  const navItems = [
+  const navItems = useMemo(() => [
     { name: "Dashboard", href: "/", icon: Heart, roles: ROUTE_PERMISSIONS.DASHBOARD },
     { name: "Volunteers", href: "/volunteers", icon: Users, roles: ROUTE_PERMISSIONS.VOLUNTEERS },
     { name: "Activities", href: "/activities", icon: Activity, roles: ROUTE_PERMISSIONS.ACTIVITIES },
@@ -22,15 +24,44 @@ export const Navigation = () => {
     { name: "Resources", href: "/resources", icon: FileText, roles: ROUTE_PERMISSIONS.RESOURCES },
     { name: "Notifications", href: "/notifications", icon: Bell, roles: ROUTE_PERMISSIONS.NOTIFICATIONS },
     // { name: "Settings", href: "/settings", icon: Settings, roles: ROUTE_PERMISSIONS.SETTINGS },
-  ];
+  ], []);
 
-  const allowedNavItems = navItems.filter(item => 
-    item.roles.some(role => user?.role.includes(role))
-  );
+  const allowedNavItems = useMemo(() => navItems.filter(item => 
+    canAccessRoute(user, item.roles)
+  ), [navItems, user]);
 
   const handleLogout = () => {
     logout();
     navigate('/login');
+  };
+
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  // Prevent background scrolling when mobile menu overlay is open
+  useEffect(() => {
+    if (isOpen) {
+      const previous = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = previous || "";
+      };
+    }
+    return;
+  }, [isOpen]);
+
+  const openLogoutConfirm = () => setIsConfirmOpen(true);
+  const closeLogoutConfirm = () => setIsConfirmOpen(false);
+
+  const confirmLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await Promise.resolve();
+      handleLogout();
+    } finally {
+      setIsLoggingOut(false);
+      closeLogoutConfirm();
+    }
   };
 
   const handleProfileClick = () => {
@@ -56,12 +87,11 @@ export const Navigation = () => {
             <div className="ml-10 flex items-baseline space-x-4">
               {allowedNavItems.map((item) => {
                 const Icon = item.icon;
-                const isActive = location.pathname === item.href;
                 return (
-                  <a
+                  <NavLink
                     key={item.name}
-                    href={item.href}
-                    className={`px-3 py-2 rounded-md text-sm font-medium flex items-center space-x-2 transition-smooth ${
+                    to={item.href}
+                    className={({ isActive }) => `px-3 py-2 rounded-md text-sm font-medium flex items-center space-x-2 transition-smooth ${
                       isActive
                         ? "bg-gradient-primary text-primary-foreground shadow-soft"
                         : "text-muted-foreground hover:text-foreground hover:bg-accent"
@@ -69,14 +99,14 @@ export const Navigation = () => {
                   >
                     <Icon className="h-4 w-4" />
                     <span>{item.name}</span>
-                  </a>
+                  </NavLink>
                 );
               })}
             </div>
           </div>
 
-          {/* Profile & Logout Section */}
-          <div className="md:block flex items-center space-x-2">
+          {/* Profile & Logout Section (desktop only) */}
+          <div className="hidden md:flex items-center space-x-2">
             <Button 
               variant="outline" 
               size="sm" 
@@ -89,7 +119,7 @@ export const Navigation = () => {
             <Button 
               variant="ghost" 
               size="sm" 
-              onClick={handleLogout}
+              onClick={openLogoutConfirm}
               className="text-red-600 hover:text-red-700"
             >
               <LogOut className="h-4 w-4 mr-2" />
@@ -103,6 +133,9 @@ export const Navigation = () => {
               variant="ghost"
               size="sm"
               onClick={() => setIsOpen(!isOpen)}
+              aria-expanded={isOpen}
+              aria-controls="mobile-menu"
+              aria-label={isOpen ? "Close main menu" : "Open main menu"}
             >
               <Menu className="h-5 w-5" />
             </Button>
@@ -112,29 +145,93 @@ export const Navigation = () => {
 
       {/* Mobile Navigation */}
       {isOpen && (
-        <div className="md:hidden">
-          <div className="px-2 pt-2 pb-3 space-y-1 bg-gradient-soft border-t border-border">
-            {allowedNavItems.map((item) => {
-              const Icon = item.icon;
-              const isActive = location.pathname === item.href;
-              return (
-                <a
-                  key={item.name}
-                  href={item.href}
-                  className={`px-3 py-2 rounded-md text-base font-medium flex items-center space-x-2 transition-smooth ${
-                    isActive
-                      ? "bg-gradient-primary text-primary-foreground"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent"
+        // Fullscreen overlay for mobile menu
+        <div className="md:hidden fixed inset-0 z-50">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setIsOpen(false)} />
+          <div className="relative h-full w-full flex flex-col bg-gradient-soft">
+            {/* Header with close button */}
+            <div className="border-b border-border">
+              <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div className="flex items-center justify-between h-16">
+                  <div className="flex items-center space-x-3">
+                    <div className="w-8 h-8 bg-gradient-primary rounded-lg flex items-center justify-center">
+                      <Heart className="h-5 w-5 text-primary-foreground" />
+                    </div>
+                    <span className="text-xl font-semibold text-foreground">VoluntALIA</span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsOpen(false)}
+                    aria-label="Close menu"
+                  >
+                    ✕
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            {/* Scrollable nav items */}
+            <div className="overflow-auto px-4 py-4 space-y-2 flex-1">
+              {allowedNavItems.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <NavLink
+                    key={item.name}
+                    to={item.href}
+                    onClick={() => setIsOpen(false)}
+                    className={({ isActive }) => `px-3 py-3 rounded-md text-base font-medium flex items-center space-x-3 transition-smooth ${
+                      isActive
+                        ? "bg-gradient-primary text-primary-foreground"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent"
+                    }`}
+                  >
+                    <Icon className="h-5 w-5" />
+                    <span>{item.name}</span>
+                  </NavLink>
+                );
+              })}
+            </div>
+
+            {/* Footer: Profile + Logout pinned to bottom */}
+            <div className="px-4 py-4 border-t border-border">
+              <div className="space-y-2">
+                <NavLink
+                  to="/profile"
+                  onClick={() => setIsOpen(false)}
+                  className={({ isActive }) => `w-full flex items-center px-3 py-3 rounded-md text-base font-medium justify-start space-x-3 transition-smooth ${
+                    isActive ? "bg-gradient-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent"
                   }`}
                 >
-                  <Icon className="h-4 w-4" />
-                  <span>{item.name}</span>
-                </a>
-              );
-            })}
+                  <Users className="h-5 w-5 mr-2" />
+                  <span>Profile</span>
+                </NavLink>
+                <button
+                  className="w-full flex items-center px-3 py-3 rounded-md text-base font-medium justify-start space-x-3 text-red-600 hover:text-red-700"
+                  onClick={() => {
+                    setIsOpen(false);
+                    openLogoutConfirm();
+                  }}
+                >
+                  <LogOut className="h-5 w-5 mr-2" />
+                  <span>Logout</span>
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       )}
+        <ConfirmDialog
+          isOpen={isConfirmOpen}
+          onClose={closeLogoutConfirm}
+          onConfirm={confirmLogout}
+          isLoading={isLoggingOut}
+          title="Confirm logout"
+          description="Are you sure you want to logout?"
+          confirmText="Logout"
+          cancelText="Cancel"
+          variant="destructive"
+        />
     </nav>
   );
 };

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,59 @@
+import { User } from "@/types/user";
+
+/**
+ * Normalize roles input to an array of strings.
+ * Accepts a single role string, an array of strings, or undefined/null.
+ */
+export function normalizeRoles(roles?: string | readonly string[] | null): string[] {
+  if (!roles) return [];
+  if (typeof roles === "string") return [roles];
+  // roles may be readonly string[]; convert to mutable string[]
+  return Array.from(roles).map((r) => String(r));
+}
+
+/**
+ * Returns true if the user has the exact role provided.
+ */
+export function hasRole(user: Pick<User, "role"> | null | undefined, role: string): boolean {
+  if (!user || !user.role) return false;
+  const userRoles: string[] = Array.isArray(user.role)
+    ? user.role
+    : String(user.role).split(",").map((s) => s.trim());
+  return userRoles.includes(role);
+}
+
+/**
+ * Returns true if the user has any of the provided roles.
+ */
+export function hasAnyRole(
+  user: Pick<User, "role"> | null | undefined,
+  roles?: string | readonly string[] | null
+): boolean {
+  const wanted = normalizeRoles(roles);
+  if (wanted.length === 0) return false;
+  if (!user || !user.role) return false;
+  const userRoles: string[] = Array.isArray(user.role)
+    ? user.role
+    : String(user.role).split(",").map((s) => s.trim());
+  return wanted.some((r) => userRoles.includes(r));
+}
+
+/**
+ * Convenience to determine if a route (allowedRoles) is accessible by the user.
+ * If allowedRoles is empty or undefined we treat the route as public (accessible).
+ */
+export function canAccessRoute(
+  user: Pick<User, "role"> | null | undefined,
+  allowedRoles?: string | readonly string[] | null
+): boolean {
+  const allowed = normalizeRoles(allowedRoles);
+  if (allowed.length === 0) return true; // public route
+  return hasAnyRole(user, allowed);
+}
+
+export default {
+  normalizeRoles,
+  hasRole,
+  hasAnyRole,
+  canAccessRoute,
+};


### PR DESCRIPTION
Centralize permission helpers and improve mobile navigation (full-screen overlay, profile/logout in footer, logout confirmation).

Key changes:
- Add `src/lib/permissions.ts` (normalizeRoles, hasRole, hasAnyRole, canAccessRoute)
- Refactor `src/components/Navigation.tsx` to use the helpers
- Mobile menu: full-screen overlay, Profile/Logout in footer, confirm logout dialog
- Block background scroll while overlay is open

Checklist:
- [ ] Verify route visibility by role (COORDINATOR / VOLUNTEER)
- [ ] Test mobile menu overlay + block background scroll
- [ ] QA logout confirmation dialog
