### PR TITLE
feat: implement edit volunteer profile functionality

### DIFF
--- a/src/components/volunteers/VolunteerCard.tsx
+++ b/src/components/volunteers/VolunteerCard.tsx
@@ -1,95 +1,128 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { MoreHorizontal, Edit, Trash2, Mail, Phone, Activity } from "lucide-react";
-import { User } from "@/types/user";
-import formatDate from "@/lib/formatDate";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  MoreHorizontal,
+  Edit,
+  Trash2,
+  Mail,
+  Phone,
+  Activity,
+} from 'lucide-react';
+import { User } from '@/types/user';
+import formatDate from '@/lib/formatDate';
 
 interface VolunteerCardProps {
-	volunteer: User;
-	onViewProfile: (volunteer: User) => void;
-	onManageActivities: (volunteer: User) => void;
-	onContact: (volunteer: User, method: 'email' | 'phone') => void;
-	onDelete: (volunteerId: string) => void;
+  volunteer: User;
+  onViewProfile: (volunteer: User) => void;
+  onEditVolunteerProfile: (volunteer: User) => void;
+  onManageActivities: (volunteer: User) => void;
+  onContact: (volunteer: User, method: 'email' | 'phone') => void;
+  onDelete: (volunteerId: string) => void;
 }
 
 export const VolunteerCard: React.FC<VolunteerCardProps> = ({
-		volunteer,
-		onViewProfile,
-		onManageActivities,
-		onContact,
-		onDelete
-	}) => {
-	return (
-		<Card className="shadow-card hover:shadow-hover transition-smooth">
-			<CardHeader>
-				<div className="flex items-center space-x-4">
-					<Avatar className="h-12 w-12">
-						<AvatarImage src="/placeholder.svg" />
-						<AvatarFallback className="bg-gradient-primary text-primary-foreground">
-						{volunteer.name.split(' ').map(n => n[0]).join('')}
-						</AvatarFallback>
-					</Avatar>
-					<div className="flex-1">
-						<CardTitle className="text-lg">{volunteer.name}</CardTitle>
-						<CardDescription>{volunteer.email}</CardDescription>
-					</div>
-					<div className="flex items-center space-x-2">
-						<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button variant="ghost" size="sm">
-							<MoreHorizontal className="h-4 w-4" />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end">
-							<DropdownMenuItem onClick={() => onContact(volunteer, 'email')}>
-							<Mail className="h-4 w-4 mr-2" />
-							Send Email
-							</DropdownMenuItem>
-							<DropdownMenuItem onClick={() => onContact(volunteer, 'phone')}>
-							<Phone className="h-4 w-4 mr-2" />
-							Call
-							</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem>
-							<Edit className="h-4 w-4 mr-2" />
-							Edit Profile
-							</DropdownMenuItem>
-							<DropdownMenuItem 
-							onClick={() => onDelete(volunteer.id)}
-							className="text-destructive focus:text-destructive"
-							>
-							<Trash2 className="h-4 w-4 mr-2" />
-							Remove
-							</DropdownMenuItem>
-						</DropdownMenuContent>
-						</DropdownMenu>
-					</div>
-				</div>
-			</CardHeader>
-			<CardContent>
-				<div className="space-y-4">
-					<div className="flex justify-between text-sm">
-						<span className="text-muted-foreground">Role:</span>
-						<span className="font-medium capitalize">{volunteer.role || 'VOLUNTEER'}</span>
-					</div>
-					<div className="flex justify-between text-sm">
-						<span className="text-muted-foreground">Joined:</span>
-						<span className="font-medium">{formatDate(volunteer.createdAt)}</span>
-					</div>
-
-					<div className="flex space-x-2 mt-4">
-						<Button variant="outline" className="flex-1" onClick={() => onViewProfile(volunteer)}>
-						View Profile
-						</Button>
-						<Button onClick={() => onManageActivities(volunteer)}>
-						<Activity className="h-4 w-4 mr-2" />
-						Activities
-						</Button>
-					</div>
-				</div>
-			</CardContent>
-			</Card>
-	);
+  volunteer,
+  onViewProfile,
+  onEditVolunteerProfile,
+  onManageActivities,
+  onContact,
+  onDelete,
+}) => {
+  return (
+    <Card className="shadow-card hover:shadow-hover transition-smooth">
+      <CardHeader>
+        <div className="flex items-center space-x-4">
+          <Avatar className="h-12 w-12">
+            <AvatarImage src="/placeholder.svg" />
+            <AvatarFallback className="bg-gradient-primary text-primary-foreground">
+              {volunteer.name
+                .split(' ')
+                .map((n) => n[0])
+                .join('')}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex-1">
+            <CardTitle className="text-lg">{volunteer.name}</CardTitle>
+            <CardDescription>{volunteer.email}</CardDescription>
+          </div>
+          <div className="flex items-center space-x-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => onContact(volunteer, 'email')}>
+                  <Mail className="h-4 w-4 mr-2" />
+                  Send Email
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onContact(volunteer, 'phone')}>
+                  <Phone className="h-4 w-4 mr-2" />
+                  Call
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => onEditVolunteerProfile(volunteer)}
+                >
+                  <Edit className="h-4 w-4 mr-2" />
+                  Edit Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => onDelete(volunteer.id)}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Remove
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Role:</span>
+            <span className="font-medium capitalize">
+              {volunteer.role || 'VOLUNTEER'}
+            </span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Joined:</span>
+            <span className="font-medium">
+              {formatDate(volunteer.createdAt)}
+            </span>
+          </div>
+          <div className="flex space-x-2 mt-4">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => onViewProfile(volunteer)}
+            >
+              View Profile
+            </Button>
+            <Button onClick={() => onManageActivities(volunteer)}>
+              <Activity className="h-4 w-4 mr-2" />
+              Activities
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
 };

--- a/src/hooks/common/useModal.ts
+++ b/src/hooks/common/useModal.ts
@@ -7,18 +7,24 @@ export interface UseModalOptions<T = any> {
 
 export const useModal = <T = any>(options: UseModalOptions<T> = {}) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isEdit, setIsEdit] = useState(false);
   const [data, setData] = useState<T | null>(null);
 
-  const openModal = useCallback((modalData?: T) => {
-    setData(modalData || null);
-    setIsOpen(true);
-    options.onOpen?.(modalData);
-  }, [options]);
+  const openModal = useCallback(
+    (modalData?: T, isEdit?: boolean) => {
+      setData(modalData || null);
+      setIsOpen(true);
+      options.onOpen?.(modalData);
+      setIsEdit(isEdit);
+    },
+    [options]
+  );
 
   const closeModal = useCallback(() => {
     setIsOpen(false);
     setData(null);
     options.onClose?.();
+    setIsEdit(false);
   }, [options]);
 
   const toggleModal = useCallback(() => {
@@ -32,8 +38,9 @@ export const useModal = <T = any>(options: UseModalOptions<T> = {}) => {
   return {
     isOpen,
     data,
+    isEdit,
     openModal,
     closeModal,
-    toggleModal
+    toggleModal,
   };
 };

--- a/src/hooks/pages/useVolunteersPage.ts
+++ b/src/hooks/pages/useVolunteersPage.ts
@@ -159,6 +159,10 @@ export const useVolunteersPage = () => {
     viewProfileModal.openModal(volunteer);
   };
 
+  const handleEditVolunteerProfile = (volunteer: User) => {
+    addVolunteerModal.openModal(volunteer, true);
+  };
+
   const handleManageActivities = (volunteer: User) => {
     activityModal.openModal(volunteer);
     setSearchActivity('');
@@ -312,6 +316,7 @@ export const useVolunteersPage = () => {
     handleDeleteVolunteer,
     handleContactVolunteer,
     handleViewProfile,
+    handleEditVolunteerProfile,
     handleManageActivities,
     handleAssignActivity,
     handleRemoveActivity,

--- a/src/hooks/user/useUpdateUser.ts
+++ b/src/hooks/user/useUpdateUser.ts
@@ -4,8 +4,8 @@ import { User } from "@/types/user";
 
 export const useUpdateUser = () => {
   const queryClient = useQueryClient();
-  
-  return useMutation<User, Error, { id: number; data: Partial<User> }>({
+
+  return useMutation<User, Error, { id: string; data: Partial<User> }>({
     mutationFn: ({ id, data }) => updateUser(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });

--- a/src/pages/Volunteers.tsx
+++ b/src/pages/Volunteers.tsx
@@ -1,17 +1,24 @@
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Plus, Filter, Users } from "lucide-react";
-import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
-import AddVolunteerModal from "@/components/modals/AddVolunteerModal";
-import ViewProfileModal from "@/components/modals/ViewProfileModal";
-import { Spinner } from "@/components/Spinner";
-import { PageLayout } from "@/components/common/PageLayout";
-import { StatsGrid } from "@/components/common/StatsGrid";
-import { SearchFilterBar } from "@/components/common/SearchFilterBar";
-import { VolunteerCard } from "@/components/volunteers/VolunteerCard";
-import { ActivityManagementModal } from "@/components/volunteers/ActivityManagementModal";
-import { AdvancedFilters } from "@/components/volunteers/AdvancedFilters";
-import { useVolunteersPage } from "@/hooks/pages/useVolunteersPage";
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Plus, Filter, Users } from 'lucide-react';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+import AddVolunteerModal from '@/components/modals/AddVolunteerModal';
+import ViewProfileModal from '@/components/modals/ViewProfileModal';
+import { Spinner } from '@/components/Spinner';
+import { PageLayout } from '@/components/common/PageLayout';
+import { StatsGrid } from '@/components/common/StatsGrid';
+import { SearchFilterBar } from '@/components/common/SearchFilterBar';
+import { VolunteerCard } from '@/components/volunteers/VolunteerCard';
+import { ActivityManagementModal } from '@/components/volunteers/ActivityManagementModal';
+import { AdvancedFilters } from '@/components/volunteers/AdvancedFilters';
+import { useVolunteersPage } from '@/hooks/pages/useVolunteersPage';
 
 const Volunteers: React.FC = () => {
   const {
@@ -21,14 +28,14 @@ const Volunteers: React.FC = () => {
     isLoading,
     error,
     stats,
-    
+
     // Pagination
     totalItems,
     totalPages,
     currentPage,
     startIndex,
     setCurrentPage,
-    
+
     // Search and filters
     searchTerm,
     setSearchTerm,
@@ -46,19 +53,20 @@ const Volunteers: React.FC = () => {
     setShowAdvancedFilters,
     clearAllFilters,
     hasActiveFilters,
-    
+
     // Activity search
     searchActivity,
     setSearchActivity,
-    
+
     // Modals
     addVolunteerModal,
     viewProfileModal,
     activityModal,
-    
+
     // Handlers
     handleDeleteVolunteer,
     handleContactVolunteer,
+    handleEditVolunteerProfile,
     handleViewProfile,
     handleManageActivities,
     handleAssignActivity,
@@ -74,13 +82,13 @@ const Volunteers: React.FC = () => {
   }
 
   if (error) {
-    return <p style={{ color: "red" }}>Error loading volunteers</p>;
+    return <p style={{ color: 'red' }}>Error loading volunteers</p>;
   }
 
   const filterOptions = [
-    { value: "all", label: "All Status" },
-    { value: "active", label: "Active" },
-    { value: "inactive", label: "Inactive" }
+    { value: 'all', label: 'All Status' },
+    { value: 'active', label: 'Active' },
+    { value: 'inactive', label: 'Inactive' },
   ];
 
   return (
@@ -103,14 +111,14 @@ const Volunteers: React.FC = () => {
         className="mb-6"
         actions={
           <div className="flex gap-2">
-            <Button 
+            <Button
               variant="outline"
               onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
             >
               <Filter className="h-4 w-4 mr-2" />
               Advanced Filters
             </Button>
-            <Button 
+            <Button
               onClick={() => addVolunteerModal.openModal()}
               className="bg-gradient-primary hover:shadow-hover transition-smooth"
             >
@@ -141,13 +149,12 @@ const Volunteers: React.FC = () => {
 
       {/* Filter Summary */}
       <div className="flex items-center justify-between text-sm text-muted-foreground mb-6">
-        <span>Showing {startIndex + 1}-{Math.min(startIndex + 6, totalItems)} of {totalItems} volunteers</span>
+        <span>
+          Showing {startIndex + 1}-{Math.min(startIndex + 6, totalItems)} of{' '}
+          {totalItems} volunteers
+        </span>
         {hasActiveFilters() && (
-          <Button 
-            variant="ghost" 
-            size="sm"
-            onClick={clearAllFilters}
-          >
+          <Button variant="ghost" size="sm" onClick={clearAllFilters}>
             Clear Filters
           </Button>
         )}
@@ -160,6 +167,7 @@ const Volunteers: React.FC = () => {
             key={volunteer.id}
             volunteer={volunteer}
             onViewProfile={handleViewProfile}
+            onEditVolunteerProfile={handleEditVolunteerProfile}
             onManageActivities={handleManageActivities}
             onContact={handleContactVolunteer}
             onDelete={handleDeleteVolunteer}
@@ -173,49 +181,58 @@ const Volunteers: React.FC = () => {
           <Pagination>
             <PaginationContent>
               <PaginationItem>
-                <PaginationPrevious 
+                <PaginationPrevious
                   href="#"
                   onClick={(e) => {
                     e.preventDefault();
                     if (currentPage > 1) setCurrentPage(currentPage - 1);
                   }}
-                  className={currentPage === 1 ? "pointer-events-none opacity-50" : ""}
+                  className={
+                    currentPage === 1 ? 'pointer-events-none opacity-50' : ''
+                  }
                 />
               </PaginationItem>
-              
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => {
-                // Show first page, last page, current page, and pages around current
-                const shouldShow = 
-                  page === 1 || 
-                  page === totalPages || 
-                  (page >= currentPage - 1 && page <= currentPage + 1);
-                
-                if (!shouldShow) return null;
-                
-                return (
-                  <PaginationItem key={page}>
-                    <PaginationLink
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setCurrentPage(page);
-                      }}
-                      isActive={currentPage === page}
-                    >
-                      {page}
-                    </PaginationLink>
-                  </PaginationItem>
-                );
-              })}
-              
+
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map(
+                (page) => {
+                  // Show first page, last page, current page, and pages around current
+                  const shouldShow =
+                    page === 1 ||
+                    page === totalPages ||
+                    (page >= currentPage - 1 && page <= currentPage + 1);
+
+                  if (!shouldShow) return null;
+
+                  return (
+                    <PaginationItem key={page}>
+                      <PaginationLink
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setCurrentPage(page);
+                        }}
+                        isActive={currentPage === page}
+                      >
+                        {page}
+                      </PaginationLink>
+                    </PaginationItem>
+                  );
+                }
+              )}
+
               <PaginationItem>
-                <PaginationNext 
+                <PaginationNext
                   href="#"
                   onClick={(e) => {
                     e.preventDefault();
-                    if (currentPage < totalPages) setCurrentPage(currentPage + 1);
+                    if (currentPage < totalPages)
+                      setCurrentPage(currentPage + 1);
                   }}
-                  className={currentPage === totalPages ? "pointer-events-none opacity-50" : ""}
+                  className={
+                    currentPage === totalPages
+                      ? 'pointer-events-none opacity-50'
+                      : ''
+                  }
                 />
               </PaginationItem>
             </PaginationContent>
@@ -229,14 +246,18 @@ const Volunteers: React.FC = () => {
           <CardContent className="p-8 text-center">
             <Users className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
             <p className="text-lg font-medium mb-2">No volunteers found</p>
-            <p className="text-muted-foreground">Try adjusting your search or filter criteria</p>
+            <p className="text-muted-foreground">
+              Try adjusting your search or filter criteria
+            </p>
           </CardContent>
         </Card>
       )}
 
       {/* Modals */}
-      <AddVolunteerModal 
+      <AddVolunteerModal
         open={addVolunteerModal.isOpen}
+        isEdit={addVolunteerModal.isEdit}
+        volunteer={addVolunteerModal.data}
         onOpenChange={addVolunteerModal.closeModal}
       />
 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,8 +1,8 @@
-import api from "@/api/axios";
-import { ENDPOINTS } from "@/api/endpoints";
-import { User } from "@/types/user";
-import { ApiResponse } from "@/types/api";
-import { camelizeKeys, snakeifyKeys } from "@/lib/caseUtils";
+import api from '@/api/axios';
+import { ENDPOINTS } from '@/api/endpoints';
+import { ApiResponse } from '@/types/api';
+import { camelizeKeys, snakeifyKeys } from '@/lib/caseUtils';
+import { User } from '@/types/user';
 
 type CreateUserResponse = {
   user: User;
@@ -17,7 +17,11 @@ export const getUsers = async (): Promise<User[]> => {
   const users = camelizeKeys<User[]>(raw).map((u) => ({
     ...u,
     // ensure createdAt exists (fallback from snake_case)
-    createdAt: u.createdAt ?? ((u as unknown as Record<string, unknown>)['created_at'] as string | undefined),
+    createdAt:
+      u.createdAt ??
+      ((u as unknown as Record<string, unknown>)['created_at'] as
+        | string
+        | undefined),
   }));
   return users;
 };
@@ -26,7 +30,9 @@ export const getCurrentUser = async (): Promise<{ user: User }> => {
   const response = await api.get(ENDPOINTS.ME);
   const raw = response.data?.user ?? response.data;
   const user = camelizeKeys<User>(raw);
-  user.createdAt = user.createdAt ?? ((raw as Record<string, unknown>)['created_at'] as string | undefined);
+  user.createdAt =
+    user.createdAt ??
+    ((raw as Record<string, unknown>)['created_at'] as string | undefined);
   return { user };
 };
 
@@ -36,25 +42,32 @@ export const getUserById = async (id: number): Promise<User> => {
 };
 
 export const createUser = async (
-  user: Omit<User, "id" | "createdAt">
+  user: Omit<User, 'id' | 'created_at'>
 ): Promise<User> => {
   // Convert outgoing keys to snake_case if backend expects it
   const payload = snakeifyKeys(user);
-  const response = await api.post<CreateUserResponse>(ENDPOINTS.REGISTER, payload);
+  const response = await api.post<CreateUserResponse>(
+    ENDPOINTS.REGISTER,
+    payload
+  );
   const raw = response.data?.user ?? response.data;
   const created = camelizeKeys<User>(raw);
-  created.createdAt = created.createdAt ?? ((raw as Record<string, unknown>)['created_at'] as string | undefined);
+  created.createdAt =
+    created.createdAt ??
+    ((raw as Record<string, unknown>)['created_at'] as string | undefined);
   return created;
 };
 
 export const updateUser = async (
-  id: number,
+  id: string,
   userData: Partial<User>
 ): Promise<User> => {
   const payload = snakeifyKeys(userData);
   const response = await api.put(`${ENDPOINTS.USERS}/${id}`, payload);
   const raw = response.data;
   const updated = camelizeKeys<User>(raw);
-  updated.createdAt = updated.createdAt ?? ((raw as Record<string, unknown>)['created_at'] as string | undefined);
+  updated.createdAt =
+    updated.createdAt ??
+    ((raw as Record<string, unknown>)['created_at'] as string | undefined);
   return updated;
 };


### PR DESCRIPTION
# Summary
Adds the ability to edit existing volunteer profiles from the Volunteers page. Coordinators can now update volunteer information (name, phone, country, city, skills) while keeping email read-only for data integrity.

# Changes
Added onEditVolunteerProfile prop to component interface
Wired up Edit Profile dropdown button with onClick handler
Passed onEditVolunteerProfile handler to VolunteerCard components
Passed isEdit and volunteer props to AddVolunteerModal
Added support for edit mode via isEdit and volunteer props
Implemented form pre-population when editing existing volunteer
Added conditional submit logic (create vs update)
Made email field read-only during edit mode
Dynamic modal title and button text based on mode
Added isEdit state to modal management
Extended openModal to accept optional isEdit parameter
Return isEdit state in hook result
Added handleEditVolunteerProfile handler
Exported handler for use in Volunteers page
Changed mutation type signature to use string ID for UUID compatibility
Changed updateUser function ID parameter type from number to string for UUID compatibility

## Screenshot
<img width="500" height="692" alt="Screenshot 2025-11-28 at 12 21 42" src="https://github.com/user-attachments/assets/fcf4a8b4-09c7-47fa-a309-0e1071547b23" />

